### PR TITLE
HHH-9836: enhance extensibility of MultipleHiLoPerTableGenerator

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/id/MultipleHiLoPerTableGenerator.java
+++ b/hibernate-core/src/main/java/org/hibernate/id/MultipleHiLoPerTableGenerator.java
@@ -98,11 +98,11 @@ public class MultipleHiLoPerTableGenerator implements PersistentIdentifierGenera
 	//hilo params
 	public static final String MAX_LO = "max_lo";
 
-	private int maxLo;
-	private LegacyHiLoAlgorithmOptimizer hiloOptimizer;
+	protected int maxLo;
+	protected LegacyHiLoAlgorithmOptimizer hiloOptimizer;
 
-	private Class returnClass;
-	private int keySize;
+	protected Class returnClass;
+	protected int keySize;
 
 	public synchronized Serializable generate(final SessionImplementor session, Object obj) {
 		final SqlStatementLogger statementLogger = session.getFactory().getServiceRegistry()


### PR DESCRIPTION
maxLo, hiloOptimizer, returnClass and keySize should be protected to allow access in custom implementations.
